### PR TITLE
sddm問題修正

### DIFF
--- a/configs/airootfs/etc/sddm.conf.d/kde_settings.conf
+++ b/configs/airootfs/etc/sddm.conf.d/kde_settings.conf
@@ -1,3 +1,0 @@
-[Autologin]
-User=live
-Session=i3-gnome-flashback-session.desktop

--- a/configs/airootfs/etc/sddm.conf.d/sddm.conf
+++ b/configs/airootfs/etc/sddm.conf.d/sddm.conf
@@ -1,0 +1,12 @@
+[AutoLogin]
+Relogin=false
+Session=i3.desktop
+User=live
+
+[General]
+HaltCommand=/usr/bin/systemctl poweroff
+RebootCommand=/usr/bin/systemctl reboot
+
+[Users]
+MaximumUid=60513
+MinimumUid=1000

--- a/configs/airootfs/usr/share/xsessions/i3.desktop
+++ b/configs/airootfs/usr/share/xsessions/i3.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=i3
+Comment=improved dynamic tiling window manager
+Exec=i3
+TryExec=i3
+Type=Application
+X-LightDM-DesktopName=i3
+DesktopNames=i3
+Keywords=tiling;wm;windowmanager;window;manager;

--- a/configs/packages.x86_64
+++ b/configs/packages.x86_64
@@ -26,7 +26,6 @@ efibootmgr
 espeakup
 ethtool
 exfatprogs
-f2fs-tools
 fatresize
 foot-terminfo
 fsarchiver
@@ -124,8 +123,15 @@ xfsprogs
 xl2tpd
 zsh
 
+#X11
+
+xorg
+xorg-server
+xapps
+
 #desktop
 
+sddm
 i3
 okular
 #konsole


### PR DESCRIPTION
・そもそもパッケージリストにsddmがなかったので追加
・X11関連を追加(i3wmはX11のみ対応)
・設定ファイルを軽く修正
・セッションにi3.desktopを追加