### PR TITLE
KDE Plasma Editionの修正に合わせた変更

### DIFF
--- a/configs/airootfs/etc/pacman.d/hooks/locale-gen.hook
+++ b/configs/airootfs/etc/pacman.d/hooks/locale-gen.hook
@@ -1,0 +1,12 @@
+# remove from airootfs!
+[Trigger]
+Operation = Install
+Operation = Upgrade
+Type = Package
+Target = glibc
+
+[Action]
+Description = Generating localisation files...
+When = PostTransaction
+Depends = glibc
+Exec = /usr/bin/locale-gen

--- a/configs/airootfs/etc/systemd/system/dbus-org.freedesktop.nm-dispatcher.service
+++ b/configs/airootfs/etc/systemd/system/dbus-org.freedesktop.nm-dispatcher.service
@@ -1,0 +1,1 @@
+/usr/lib/systemd/system/NetworkManager-dispatcher.service

--- a/configs/airootfs/root/customize_airootfs.sh
+++ b/configs/airootfs/root/customize_airootfs.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+## Script to perform several important tasks before `mkarchiso` create filesystem image.
+
+set -e -u
+
+
+## Fix Initrd Generation in Installed System
+cat > "/etc/mkinitcpio.d/linux.preset" <<- _EOF_
+	# mkinitcpio preset file for the 'linux' package
+
+	#ALL_config="/etc/mkinitcpio.conf"
+	ALL_kver="/boot/vmlinuz-linux"
+
+	PRESETS=('default' 'fallback')
+
+	#default_config="/etc/mkinitcpio.conf"
+	default_image="/boot/initramfs-linux.img"
+	#default_options=""
+
+	#fallback_config="/etc/mkinitcpio.conf"
+	fallback_image="/boot/initramfs-linux-fallback.img"
+	#fallback_uki="/efi/EFI/Linux/arch-linux-fallback.efi"
+	fallback_options="-S autodetect"
+_EOF_

--- a/configs/grub/grub.cfg
+++ b/configs/grub/grub.cfg
@@ -56,13 +56,13 @@ timeout_style=menu
 
 menuentry "Krypton Live (%ARCH%, ${archiso_platform})" --class arch --class gnu-linux --class gnu --class os --id 'archlinux' {
     set gfxpayload=keep
-    linux /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID%
+    linux /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% copytoram=n cow_space=4G quiet loglevel=3
     initrd /%INSTALL_DIR%/boot/%ARCH%/initramfs-linux.img
 }
 
 menuentry "Krypton Live with speakup screen reader (%ARCH%, ${archiso_platform})" --hotkey s --class arch --class gnu-linux --class gnu --class os --id 'archlinux-accessibility' {
     set gfxpayload=keep
-    linux /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% accessibility=on
+    linux /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% accessibility=on copytoram=n cow_space=4G quiet loglevel=3
     initrd /%INSTALL_DIR%/boot/%ARCH%/initramfs-linux.img
 }
 

--- a/configs/syslinux/archiso_sys-linux.cfg
+++ b/configs/syslinux/archiso_sys-linux.cfg
@@ -6,7 +6,7 @@ ENDTEXT
 MENU LABEL Arch Linux install medium (x86_64, BIOS)
 LINUX /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux
 INITRD /%INSTALL_DIR%/boot/x86_64/initramfs-linux.img
-APPEND archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID%
+APPEND archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% copytoram=n cow_space=4G quiet loglevel=3
 
 # Accessibility boot option
 LABEL arch64speech
@@ -17,4 +17,4 @@ ENDTEXT
 MENU LABEL Arch Linux install medium (x86_64, BIOS) with ^speech
 LINUX /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux
 INITRD /%INSTALL_DIR%/boot/x86_64/initramfs-linux.img
-APPEND archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% accessibility=on
+APPEND archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% accessibility=on copytoram=n cow_space=4G quiet loglevel=3


### PR DESCRIPTION
# 変更点

<li>Initrd生成の設定がarchiso向けになっているので、インストール後に問題を起こさないよう、SquashFS圧縮直前でinitrd生成をシェルスクリプトで修正する変更</li>
<li>そのままだとlocaleが生成されないので、locale-genのhookを追加</li>
<li>インストール時にエラーが発生するため、copytoramを無効化←これ重要</li>
<li>起動時のloglevelを3に設定</li>
<li>ライブ環境でのディスク容量が少ないというエラーメッセージを防ぐため、cowspaceを4GBに設定</li>
<li>ライブ環境でNetworkManagerを有効化</li>

---

迫りくる期末テスト
@Soyo-Wind 