### PR TITLE
airootfs/usr/share/xsessions/i3.desktopを削除

### DIFF
--- a/configs/airootfs/usr/share/xsessions/i3.desktop
+++ b/configs/airootfs/usr/share/xsessions/i3.desktop
@@ -1,9 +1,0 @@
-[Desktop Entry]
-Name=i3
-Comment=improved dynamic tiling window manager
-Exec=i3
-TryExec=i3
-Type=Application
-X-LightDM-DesktopName=i3
-DesktopNames=i3
-Keywords=tiling;wm;windowmanager;window;manager;


### PR DESCRIPTION
i3.desktopが存在していたためpacmanの仕様でパッケージのインストールがキャンセルされてしまっていたようです。
i3.desktopを削除しました。

あと、warningは循環依存によるもので問題はありません。